### PR TITLE
Set up Coveralls and add tests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,7 +4,8 @@ python:
   - "3.2"
   - "3.3"
   - "3.4"
-install: "pip install -r requirements.txt"
-script: "make test"
+before_script: pip install python-coveralls
+script: make test
+after_success: coveralls
 notifications:
   email: false

--- a/README.rst
+++ b/README.rst
@@ -5,6 +5,12 @@ stronglib is an Apache2 licensed Python library for the
 `STRONGARM <http://strongarm.io>`_
 `API <https://strongarm.percipientnetworks.com/api/>`_.
 
+.. image:: https://travis-ci.org/percipient/stronglib.svg?branch=master
+    :target: https://travis-ci.org/percipient/stronglib
+
+.. image:: https://coveralls.io/repos/percipient/stronglib/badge.svg?branch=master
+    :target: https://coveralls.io/github/percipient/stronglib
+
 features
 --------
 

--- a/setup.py
+++ b/setup.py
@@ -12,9 +12,9 @@ class PyTest(TestCommand):
     def finalize_options(self):
         TestCommand.finalize_options(self)
         self.test_args = [
-            '--cov', './strongarm', '--cov', './tests',
+            '--cov', './strongarm',
             '--doctest-modules', '--verbose',
-            './strongarm', './tests'
+            './tests'
         ]
         self.test_suite = True
 

--- a/strongarm/common.py
+++ b/strongarm/common.py
@@ -1,5 +1,5 @@
 import requests
-from six import integer_types
+from six import integer_types, iteritems
 from six.moves import xrange
 
 import strongarm
@@ -140,7 +140,7 @@ class Struct(object):
 
         self.__dict__.update(dictionary)
 
-        for k, v in self.__dict__.iteritems():
+        for k, v in iteritems(self.__dict__):
             if isinstance(v, dict):
                 self.__dict__[k] = Struct(v)
 

--- a/tests/test_common.py
+++ b/tests/test_common.py
@@ -8,7 +8,7 @@ import responses
 from six.moves.urllib.parse import parse_qs, urlparse
 
 import strongarm
-from strongarm.common import PaginatedResourceList
+from strongarm.common import Struct, PaginatedResourceList
 
 
 class StrongarmTestCase(unittest.TestCase):
@@ -23,6 +23,27 @@ class StrongarmTestCase(unittest.TestCase):
         with self.assertRaises(strongarm.StrongarmUnauthorized):
             strongarm.api_key = 'bad_token'
             strongarm.Domain.all()
+
+
+class StructTestCase(unittest.TestCase):
+
+    def test_recursive_traversal(self):
+        """
+        Test that the struct faithfully represent the structure of the given
+        dictionary.
+
+        """
+        d = {'a': 1,
+             'b': {'c': 2, 'd': 3},
+             'e': {'f': {'g': ('test', 42)}},
+             'h': 'value'}
+
+        struct = Struct(d)
+        self.assertEqual(struct.a, 1)
+        self.assertEqual(struct.b.c, 2)
+        self.assertEqual(struct.b.d, 3)
+        self.assertEqual(struct.e.f.g, ('test', 42))
+        self.assertEqual(struct.h, 'value')
 
 
 class PaginationTestCase(unittest.TestCase):
@@ -61,6 +82,15 @@ class PaginationTestCase(unittest.TestCase):
                                callback=paginated_resource,
                                content_type='application/json')
 
+    def lazy_pages(self, index):
+        """
+        How many pages the lazy list should have requested to get to index.
+
+        """
+        if index < 0:
+            index += self.total
+        return index // self.per_page + 1
+
     @responses.activate
     def test_init_lazy(self):
         """
@@ -81,19 +111,33 @@ class PaginationTestCase(unittest.TestCase):
         self.plist = PaginatedResourceList(int, self.endpoint)
 
         self.assertEqual(self.plist[2], 2)
-        self.assertEqual(len(responses.calls), 1)
+        self.assertEqual(len(responses.calls), self.lazy_pages(2))
 
         self.assertEqual(self.plist[5], 5)
-        self.assertEqual(len(responses.calls), 2)
+        self.assertEqual(len(responses.calls), self.lazy_pages(5))
 
         self.assertEqual(self.plist[10], 10)
-        self.assertEqual(len(responses.calls), 3)
+        self.assertEqual(len(responses.calls), self.lazy_pages(10))
 
         self.assertEqual(self.plist[13], 13)
-        self.assertEqual(len(responses.calls), 4)
+        self.assertEqual(len(responses.calls), self.lazy_pages(13))
 
     @responses.activate
-    def test_index_error(self):
+    def test_index_negative(self):
+        """
+        Test that when negative indices are handled correctly and lazily.
+
+        """
+        self.plist = PaginatedResourceList(int, self.endpoint)
+
+        self.assertEqual(self.plist[-12], self.total - 12)
+        self.assertEqual(len(responses.calls), self.lazy_pages(-12))
+
+        self.assertEqual(self.plist[-1], self.total - 1)
+        self.assertEqual(len(responses.calls), self.lazy_pages(-1))
+
+    @responses.activate
+    def test_index_out_of_bounds(self):
         """
         Test that when an out-of-bounds index is passed in, an error is thrown
         without requesting additional pages.
@@ -105,6 +149,19 @@ class PaginationTestCase(unittest.TestCase):
         self.assertEqual(len(responses.calls), 1)
 
     @responses.activate
+    def test_index_type_error(self):
+        """
+        Test that when an incorrectly typed index is passed in, an error is
+        thrown without requesting additional pages.
+
+        """
+        self.plist = PaginatedResourceList(int, self.endpoint)
+
+        self.assertRaises(TypeError, lambda: self.plist['a'])
+        self.assertEqual(len(responses.calls), 1)
+
+
+    @responses.activate
     def test_slice_lazy(self):
         """
         Test that when it's being sliced, the paginated list only requests the
@@ -114,13 +171,13 @@ class PaginationTestCase(unittest.TestCase):
         self.plist = PaginatedResourceList(int, self.endpoint)
 
         self.assertEqual(self.plist[1:3], list(range(1, 3)))
-        self.assertEqual(len(responses.calls), 1)
+        self.assertEqual(len(responses.calls), self.lazy_pages(2))
 
         self.assertEqual(self.plist[1:7:2], list(range(1, 7, 2)))
-        self.assertEqual(len(responses.calls), 2)
+        self.assertEqual(len(responses.calls), self.lazy_pages(6))
 
         self.assertEqual(self.plist[10:13], list(range(10, 13)))
-        self.assertEqual(len(responses.calls), 4)
+        self.assertEqual(len(responses.calls), self.lazy_pages(12))
 
     @responses.activate
     def test_list_cast(self):
@@ -133,4 +190,4 @@ class PaginationTestCase(unittest.TestCase):
 
         entire_list = list(self.plist)
         self.assertEqual(entire_list, list(range(self.total)))
-        self.assertEqual(len(responses.calls), 4)
+        self.assertEqual(len(responses.calls), self.lazy_pages(self.total-1))

--- a/tests/test_dns_integration.py
+++ b/tests/test_dns_integration.py
@@ -10,10 +10,13 @@ from strongarm.dns_integration import (DnsBlackholeIncrementalUpdater,
 class StrongarmDnsTestCase(unittest.TestCase):
 
     def test_unimplemented(self):
-        """Test that running the base class directly raises NotImplemented."""
+        """Test that running the base classes directly raises NotImplemented."""
 
         with self.assertRaises(NotImplementedError):
             DnsBlackholeUpdater('127.0.0.1').update_domains(['example.com'])
+
+        with self.assertRaises(NotImplementedError):
+            DnsBlackholeIncrementalUpdater('127.0.0.1').update_domains(['example.com'])
 
     def test_incremental_update(self):
         """


### PR DESCRIPTION
This makes test coverage available on [coveralls](https://coveralls.io/github/percipient/stronglib). Some tests were added to bring coverage above 90%, and a Python 3 compatibility issue is found and fixed along the way.