### PR TITLE
Add ability to create (POST) and delete resources

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -15,7 +15,7 @@ features
 --------
 
 - token authentication
-- get list of blackholed domains
+- get, create, and delete blackholed domains
 
 installation
 ------------
@@ -30,8 +30,6 @@ installed directly from GitHub:
 usage
 -----
 
-Currently the STRONGARM API supports listing all domains.
-
 .. code-block:: python
 
     import strongarm
@@ -42,6 +40,12 @@ Currently the STRONGARM API supports listing all domains.
     # list all blackholed domains
     for domain in strongarm.Domain.all():
         print(domain.name)
+
+    # create a new blackholed domain
+    domain = strongarm.Domain.create(name='example.com')
+
+    # delete a blackholed domain
+    domain.delete()
 
 contribute
 ----------

--- a/README.rst
+++ b/README.rst
@@ -37,6 +37,10 @@ usage
     # token authentication
     strongarm.api_key = 'your_api_token'
 
+    # get (ie, search) a single Domain
+    domain = strongarm.Domain.get('example.com')
+    print(domain.name)
+
     # list all blackholed domains
     for domain in strongarm.Domain.all():
         print(domain.name)

--- a/strongarm/__init__.py
+++ b/strongarm/__init__.py
@@ -13,5 +13,6 @@ host = 'https://strongarm.percipientnetworks.com'
 api_key = None
 
 
-from strongarm.common import (StrongarmException, StrongarmUnauthorized)
+from strongarm.common import (StrongarmException, StrongarmHttpError,
+                              StrongarmUnauthorized)
 from strongarm.resources import Domain

--- a/strongarm/common.py
+++ b/strongarm/common.py
@@ -226,3 +226,19 @@ class CreatableResource(object):
         endpoint = strongarm.host + cls.endpoint
         return cls(request('post', endpoint, data=json.dumps(kwargs),
                            headers={'Content-Type': 'application/json'}))
+
+
+class DeletableResource(object):
+    """
+    A mixin for a STRONGARM resource that can be deleted.
+
+    The `delete` method returns None on successful deletion.
+
+    """
+
+    # The attribute to be used as the unique identifier.
+    id_attr = 'id'
+
+    def delete(self, **kwargs):
+        endpoint = strongarm.host + self.endpoint + str(getattr(self, self.id_attr))
+        request('delete', endpoint)

--- a/strongarm/common.py
+++ b/strongarm/common.py
@@ -1,3 +1,5 @@
+import json
+
 import requests
 from six import integer_types, iteritems
 from six.moves import xrange
@@ -209,3 +211,18 @@ class ListableResource(object):
     def all(cls):
         endpoint = strongarm.host + cls.endpoint
         return PaginatedResourceList(cls, endpoint)
+
+
+class CreatableResource(object):
+    """
+    A mixin for a STRONGARM resource that can be created.
+
+    The `create` method returns an instance of the newly created resource.
+
+    """
+
+    @classmethod
+    def create(cls, **kwargs):
+        endpoint = strongarm.host + cls.endpoint
+        return cls(request('post', endpoint, data=json.dumps(kwargs),
+                           headers={'Content-Type': 'application/json'}))

--- a/strongarm/resources.py
+++ b/strongarm/resources.py
@@ -1,5 +1,6 @@
-from strongarm.common import StrongResource, ListableResource
+from strongarm.common import (CreatableResource, ListableResource,
+                              StrongResource)
 
 
-class Domain(StrongResource, ListableResource):
+class Domain(StrongResource, ListableResource, CreatableResource):
     endpoint = '/api/domains/'

--- a/strongarm/resources.py
+++ b/strongarm/resources.py
@@ -1,6 +1,9 @@
-from strongarm.common import (CreatableResource, ListableResource,
-                              StrongResource)
+from strongarm.common import (CreatableResource, DeletableResource,
+                              ListableResource, StrongResource)
 
 
-class Domain(StrongResource, ListableResource, CreatableResource):
+class Domain(StrongResource, CreatableResource, DeletableResource, ListableResource):
     endpoint = '/api/domains/'
+
+    # The domain name is used as the unique identifier passed in the url.
+    id_attr = 'name'

--- a/tests/test_resources.py
+++ b/tests/test_resources.py
@@ -1,0 +1,183 @@
+"Tests for strongarm.resources."""
+
+import json
+import unittest
+
+import responses
+
+import strongarm
+from strongarm.resources import Domain
+
+
+class DomainTestCase(unittest.TestCase):
+
+    list_response = {
+        "count": 5,
+        "next": None,
+        "previous": None,
+        "results": [
+            {
+                "name": "0.example.com",
+                "user": "malwaredomainlist",
+                "date": "2015-08-05T18:19:14Z"
+            },
+            {
+                "name": "1.example.com",
+                "user": "zeustracker",
+                "date": "2015-07-28T16:22:39Z"
+            },
+            {
+                "name": "2.example.com",
+                "user": "malwaredomainlist",
+                "date": "2015-07-28T16:23:41Z"
+            },
+            {
+                "name": "3.example.com",
+                "user": "malwaredomainlist",
+                "date": "2015-07-28T16:22:57Z"
+            },
+            {
+                "name": "example.org",
+                "user": "malwaredomainlist",
+                "date": "2015-07-28T16:22:55Z"
+            }
+        ]
+    }
+
+    get_response = {
+        "name": "0.example.com",
+        "user": "malwaredomainlist",
+        "date": "2015-08-05T18:19:14Z"
+    }
+
+    @responses.activate
+    def test_list(self):
+        """
+        Test that getting all domains returns a PaginatedResourceList with the
+        right elements.
+
+        """
+
+        responses.add(responses.GET, strongarm.host + Domain.endpoint,
+                      body=json.dumps(self.list_response),
+                      content_type='application/json')
+
+        domains = Domain.all()
+
+        self.assertEqual(len(responses.calls), 1)
+
+        self.assertEqual(len(domains), self.list_response['count'])
+        self.assertIsInstance(domains[0], Domain)
+        self.assertEqual(domains[0].name, self.list_response['results'][0]['name'])
+
+    @responses.activate
+    def test_get_exists(self):
+        """
+        Test that getting an existing blackholed domain returns an instance of
+        Domain with the right attributes.
+
+        """
+
+        name = self.get_response['name']
+
+        responses.add(responses.GET, strongarm.host + Domain.endpoint + name,
+                      body=json.dumps(self.get_response),
+                      content_type='application/json/')
+
+        domain = Domain.get(name)
+
+        self.assertEqual(len(responses.calls), 1)
+
+        self.assertIsInstance(domain, Domain)
+        self.assertEqual(domain.name, name)
+
+    @responses.activate
+    def test_get_not_found(self):
+        """
+        Test that getting a non-existent domain raises a StrongarmHttpError.
+
+        """
+
+        name = 'non-existent.example.com'
+        msg = 'Domain does not exist.'
+
+        responses.add(responses.GET, strongarm.host + Domain.endpoint + name,
+                      status=404, content_type='application/json',
+                      body=json.dumps({'detail': msg}))
+
+        with self.assertRaises(strongarm.StrongarmHttpError) as exp:
+            Domain.get(name)
+
+        self.assertEqual(len(responses.calls), 1)
+
+        self.assertEqual(exp.exception.status_code, 404)
+        self.assertEqual(exp.exception.detail, msg)
+
+    @responses.activate
+    def test_create(self):
+        """
+        Test that creating a new blackholed domain returns an instance of
+        Domain with the right attributes.
+
+        """
+
+        name = self.get_response['name']
+
+        responses.add(responses.POST, strongarm.host + Domain.endpoint,
+                      body=json.dumps(self.get_response),
+                      content_type='application/json')
+
+        domain = Domain.create(name=name)
+
+        self.assertEqual(len(responses.calls), 1)
+
+        self.assertIsInstance(domain, Domain)
+        self.assertEqual(domain.name, name)
+
+    @responses.activate
+    def test_delete_success(self):
+        """
+        Test that deleting a domain succeeds silently.
+
+        """
+
+        name = self.get_response['name']
+
+        responses.add(responses.GET, strongarm.host + Domain.endpoint + name,
+                      body=json.dumps(self.get_response),
+                      content_type='application/json/')
+        responses.add(responses.DELETE, strongarm.host + Domain.endpoint + name,
+                      status=204)
+
+        # First get the domain to be deleted
+        domain = Domain.get(name)
+
+        self.assertEqual(len(responses.calls), 1)
+
+        # Now delete the domain.
+        result = domain.delete()
+
+        self.assertEqual(len(responses.calls), 2)
+        self.assertIsNone(result)
+
+    @responses.activate
+    def test_delete_not_found(self):
+        """
+        Test that deleting a non-existent domain raises StrongarmHttpError.
+
+        """
+
+        name = 'non-existent.example.com'
+
+        responses.add(responses.DELETE, strongarm.host + Domain.endpoint + name,
+                      status=404)
+
+        # Create the Domain instance manually.
+        domain = Domain({'name': name})
+
+        # Now delete the domain.
+        with self.assertRaises(strongarm.StrongarmHttpError) as exp:
+            domain.delete()
+
+        self.assertEqual(len(responses.calls), 1)
+        self.assertEqual(exp.exception.status_code, 404)


### PR DESCRIPTION
This makes it possible to create a new domain and delete an existing one.

`create` is a class method that takes in keyword arguments to be POSTed as json.
`delete` is a regular method that can be called on an instance of a resource.

Example usage:

    >>> example = strongarm.Domain.create(name='example.com')
    >>> example
    Domain({u'date': u'2015-08-05T21:08:06.316441Z', u'name': u'example.com', u'user': u'owen'})
    >>> example.delete()

Todo:
- [x] Discuss architecture
- [x] Update documentation
- [x] Improve test coverage