### PR TITLE
Lazily fetch domain list pages in DNS integration

### DIFF
--- a/strongarm/dns_integration.py
+++ b/strongarm/dns_integration.py
@@ -44,7 +44,7 @@ class DnsBlackholeUpdater(object):
 
         strongarm.api_key = token
 
-        domains = [domain.name for domain in strongarm.Domain.all()]
+        domains = (domain.name for domain in strongarm.Domain.all())
 
         return self.update_domains(domains)
 

--- a/strongarm/dns_integration.py
+++ b/strongarm/dns_integration.py
@@ -44,6 +44,8 @@ class DnsBlackholeUpdater(object):
 
         strongarm.api_key = token
 
+        # Use a generator expression to ensure domain pages are lazily fetched
+        # as they are being processed in `update_domains`.
         domains = (domain.name for domain in strongarm.Domain.all())
 
         return self.update_domains(domains)


### PR DESCRIPTION
This changes a list comprehension to a generator comprehension to make sure the domain list pages are fetched lazily as they are being processed. Tests are added to verify this behavior.