### PR TITLE
Prepare for initial release to PyPI.

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -20,8 +20,15 @@ features
 installation
 ------------
 
-stronglib is still in beta. The **latest development version** can be
-installed directly from GitHub:
+*stronglib is still in beta.*
+
+The **latest release** can be installed from PyPI:
+
+.. code-block:: bash
+
+  $ pip install --upgrade stronglib
+
+The **latest development version** can be installed directly from GitHub:
 
 .. code-block:: bash
 

--- a/setup.py
+++ b/setup.py
@@ -62,7 +62,7 @@ setup(
     tests_require=tests_require,
     cmdclass={'test': PyTest},
     classifiers=[
-        'Development Status :: 2 - Pre-Alpha',
+        'Development Status :: 4 - Beta',
         'Programming Language :: Python',
         'Programming Language :: Python :: 2',
         'Programming Language :: Python :: 2.7',

--- a/strongarm/__init__.py
+++ b/strongarm/__init__.py
@@ -5,7 +5,7 @@ stronglib - a Python library for the STRONGARM API
 
 
 __author__ = 'Percipient Networks, LLC'
-__version__ = 'dev'
+__version__ = '0.1.0'
 __license__ = 'Apache 2.0'
 
 


### PR DESCRIPTION
Set package version number to 0.1.0. Update Trove classifiers. Update README.md to reflect installing latest version from PyPI.

Fix #3 