### PR TITLE
Update API version and package version.

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -3,6 +3,11 @@
 release history
 ---------------
 
+0.1.1 (2015-08-17)
+++++++++++++++++++
+
+* update API version header to match http://strongarm.io
+
 0.1.0 (2015-08-12)
 ++++++++++++++++++
 

--- a/README.rst
+++ b/README.rst
@@ -20,8 +20,6 @@ features
 installation
 ------------
 
-*stronglib is still in beta.*
-
 The **latest release** can be installed from PyPI:
 
 .. code-block:: bash

--- a/strongarm/__init__.py
+++ b/strongarm/__init__.py
@@ -5,12 +5,13 @@ stronglib - a Python library for the STRONGARM API
 
 
 __author__ = 'Percipient Networks, LLC'
-__version__ = '0.1.0'
+__version__ = '0.1.1'
 __license__ = 'Apache 2.0'
 
 
 host = 'https://strongarm.percipientnetworks.com'
 api_key = None
+api_version = '0.1.0'  # Developers generally should not change this.
 
 
 from strongarm.common import (StrongarmException, StrongarmHttpError,

--- a/strongarm/common.py
+++ b/strongarm/common.py
@@ -53,7 +53,8 @@ def request(method, endpoint, **kwargs):
     kwargs['headers']['Authorization'] = 'Token %s' % strongarm.api_key
 
     # Explicitly specify the API version for future-proofing.
-    kwargs['headers']['Accept'] = 'application/json; version=1.0'
+    kwargs['headers']['Accept'] = ('application/json; version=%s' %
+                                   strongarm.api_version)
 
     res = requests.request(method, endpoint, **kwargs)
 

--- a/tests/test_common.py
+++ b/tests/test_common.py
@@ -58,7 +58,7 @@ class RequestTestCase(unittest.TestCase):
 
         """
 
-        correct_header = 'application/json; version=1.0'
+        correct_header = 'application/json; version=%s' % strongarm.api_version
 
         def assert_header(request):
 


### PR DESCRIPTION
The test that verifies the version header is more flexible as well.

I will cut a release to PyPI once merged!