### PR TITLE
Ensure create and delete endpoints have a trailing slash.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -65,6 +65,9 @@ docs/_build
 # Ignore the .aptCache directory.
 .aptCache
 
+# Ignore the test cache directory.
+.cache
+
 # environment variables files used by honcho/foreman
 .env
 

--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -3,6 +3,12 @@
 release history
 ---------------
 
+0.1.2 (2015-11-23)
+++++++++++++++++++
+
+* update API host to use https://strongarm.io
+* update API endpoints to always have a trailing slash
+
 0.1.1 (2015-08-17)
 ++++++++++++++++++
 

--- a/strongarm/__init__.py
+++ b/strongarm/__init__.py
@@ -5,7 +5,7 @@ stronglib - a Python library for the STRONGARM API
 
 
 __author__ = 'Percipient Networks, LLC'
-__version__ = '0.1.1'
+__version__ = '0.1.2'
 __license__ = 'Apache 2.0'
 
 

--- a/strongarm/common.py
+++ b/strongarm/common.py
@@ -200,6 +200,8 @@ class StrongResource(Struct):
     @classmethod
     def get(cls, id):
         endpoint = strongarm.host + cls.endpoint + str(id)
+        if not endpoint.endswith('/'):
+            endpoint = endpoint + '/'
         return cls(request('get', endpoint))
 
 
@@ -246,4 +248,6 @@ class DeletableResource(object):
 
     def delete(self, **kwargs):
         endpoint = strongarm.host + self.endpoint + str(getattr(self, self.id_attr))
+        if not endpoint.endswith('/'):
+            endpoint = endpoint + '/'
         request('delete', endpoint)

--- a/tests/test_resources.py
+++ b/tests/test_resources.py
@@ -80,7 +80,7 @@ class DomainTestCase(unittest.TestCase):
 
         name = self.get_response['name']
 
-        responses.add(responses.GET, strongarm.host + Domain.endpoint + name,
+        responses.add(responses.GET, strongarm.host + Domain.endpoint + name + '/',
                       body=json.dumps(self.get_response),
                       content_type='application/json/')
 
@@ -101,7 +101,7 @@ class DomainTestCase(unittest.TestCase):
         name = 'non-existent.example.com'
         msg = 'Domain does not exist.'
 
-        responses.add(responses.GET, strongarm.host + Domain.endpoint + name,
+        responses.add(responses.GET, strongarm.host + Domain.endpoint + name + '/',
                       status=404, content_type='application/json',
                       body=json.dumps({'detail': msg}))
 
@@ -143,10 +143,10 @@ class DomainTestCase(unittest.TestCase):
 
         name = self.get_response['name']
 
-        responses.add(responses.GET, strongarm.host + Domain.endpoint + name,
+        responses.add(responses.GET, strongarm.host + Domain.endpoint + name + '/',
                       body=json.dumps(self.get_response),
                       content_type='application/json/')
-        responses.add(responses.DELETE, strongarm.host + Domain.endpoint + name,
+        responses.add(responses.DELETE, strongarm.host + Domain.endpoint + name + '/',
                       status=204)
 
         # First get the domain to be deleted
@@ -169,7 +169,7 @@ class DomainTestCase(unittest.TestCase):
 
         name = 'non-existent.example.com'
 
-        responses.add(responses.DELETE, strongarm.host + Domain.endpoint + name,
+        responses.add(responses.DELETE, strongarm.host + Domain.endpoint + name + '/',
                       status=404)
 
         # Create the Domain instance manually.


### PR DESCRIPTION
Ideally, we may want to consider supporting both trailing and non-trailing slashes. DRF explains their support well here: http://www.django-rest-framework.org/api-guide/routers/

For now, I suggest we simply ensure endpoints have a trailing slash in stronglib.