### PR TITLE
Add support for removing duplicates in PaginatedResourceList

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,8 +4,13 @@ python:
   - "3.2"
   - "3.3"
   - "3.4"
-before_script: pip install python-coveralls
 script: inv test
 after_success: coveralls
 notifications:
   email: false
+install:
+  # Coveralls 4.0 doesn't support Python 3.2
+  - pip install -r requirements.txt
+  - pip install python-coveralls
+  - if [ "$TRAVIS_PYTHON_VERSION" == "3.2" ]; then travis_retry pip install coverage==3.7.1; fi
+  - if [ "$TRAVIS_PYTHON_VERSION" != "3.2" ]; then travis_retry pip install coverage; fi

--- a/setup.py
+++ b/setup.py
@@ -24,9 +24,9 @@ class PyTest(TestCommand):
 
 
 tests_require = [
-    'pytest>=2.6.4',
-    'pytest-cov==1.8.1',
-    'responses==0.4.0',
+    'pytest',
+    'pytest-cov',
+    'responses',
 ]
 
 

--- a/strongarm/common.py
+++ b/strongarm/common.py
@@ -56,7 +56,7 @@ def request(method, endpoint, **kwargs):
     kwargs['headers']['Accept'] = ('application/json; version=%s' %
                                    strongarm.api_version)
 
-    res = requests.request(method, endpoint, verify=False, **kwargs)
+    res = requests.request(method, endpoint, **kwargs)
 
     # Raise StrongarmUnauthorized for HTTP 401 Unauthorized.
     if res.status_code == requests.codes.unauthorized:

--- a/tox.ini
+++ b/tox.ini
@@ -10,4 +10,3 @@ skip_missing_interpreters = True
 [testenv]
 commands = {envpython} setup.py test
 deps =
-


### PR DESCRIPTION
The [strongarm.io](https://strongarm.io) can return duplicate `Domain` objects. This adds support to compensate for this scenario client side as well as add a `count` method which returns an accurate de-duplicated count.