### PR TITLE
Allow disabling of certificate checking for development.

### DIFF
--- a/strongarm/__init__.py
+++ b/strongarm/__init__.py
@@ -13,6 +13,9 @@ host = 'https://strongarm.io'
 api_key = None
 api_version = '0.1.0'  # Developers generally should not change this.
 
+# This should never be set to True in a production environment and exists purely
+# for testing.
+_ignore_certificates = False
 
 from strongarm.common import (StrongarmException, StrongarmHttpError,
                               StrongarmUnauthorized)

--- a/strongarm/common.py
+++ b/strongarm/common.py
@@ -56,6 +56,11 @@ def request(method, endpoint, **kwargs):
     kwargs['headers']['Accept'] = ('application/json; version=%s' %
                                    strongarm.api_version)
 
+    # This should only be used for development, never in a production
+    # environment.
+    if strongarm._ignore_certificates is True:
+       kwargs['verify'] = False
+
     res = requests.request(method, endpoint, **kwargs)
 
     # Raise StrongarmUnauthorized for HTTP 401 Unauthorized.


### PR DESCRIPTION
When using a development server with a self-signed certificate it is required to disable certificate checking. Create a hidden configuration flag to send `verify=False` to requests.