### PR TITLE
Add infection endpoint

### DIFF
--- a/strongarm/__init__.py
+++ b/strongarm/__init__.py
@@ -19,4 +19,4 @@ _ignore_certificates = False
 
 from strongarm.common import (StrongarmException, StrongarmHttpError,
                               StrongarmUnauthorized)
-from strongarm.resources import Domain
+from strongarm.resources import Domain, Infection

--- a/strongarm/common.py
+++ b/strongarm/common.py
@@ -247,6 +247,7 @@ class ListableResource(object):
     contains all instances of the requested resource.
 
     """
+    id_attr = None
 
     @classmethod
     def all(cls):

--- a/strongarm/resources.py
+++ b/strongarm/resources.py
@@ -7,3 +7,7 @@ class Domain(StrongResource, CreatableResource, DeletableResource, ListableResou
 
     # The domain name is used as the unique identifier passed in the url.
     id_attr = 'name'
+
+
+class Infection(StrongResource, ListableResource):
+    endpoint = '/api/infections/'


### PR DESCRIPTION
This adds support for listing and getting infections.

Note that this is not yet in the deployed strongarm.io instance and must be run with a test server.

```python
import strongarm

# Configure strongarm host/api_key/certificate checking.

# list all infections
infections = [infection for infection in strongarm.Infection.all()]

print(infections)

print(strongarm.Infection.get(infections[0].id))
```