### PR TITLE
Upgrade invoke to 0.13.0.

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -7,4 +7,4 @@
 tox==2.3.1
 
 # Include invoke in dev.
-invoke==0.12.2
+invoke==0.13.0

--- a/tasks/__init__.py
+++ b/tasks/__init__.py
@@ -3,76 +3,76 @@ from invoke import run, task
 import strongarm
 
 @task
-def version():
+def version(ctx):
     """Return the current version of stronglib."""
     print(strongarm.__version__)
 
 
 @task
-def clean():
+def clean(ctx):
     """Remove various build, test, and coverage artifacts."""
     run('rm -rf .tox *.egg dist build .coverage')
     run('find . -name \'__pycache__\' -delete -print -o -name \'*.pyc\' -delete -print')
 
 
 @task
-def build():
+def build(ctx):
     """Build stronglib."""
     run('python setup.py build')
 
 
 @task
-def uninstall():
+def uninstall(ctx):
     """Uninstall stronglib."""
-    clean()
+    clean(ctx)
     run('pip uninstall --yes stronglib')
 
 
 @task
-def uninstall_all():
+def uninstall_all(ctx):
     """Uninstall stronglib, dependencies, and development dependencies."""
-    clean()
+    clean(ctx)
     run('pip uninstall --yes -r requirements.txt')
 
 
 @task
-def test():
+def test(ctx):
     """Run stronglib unittests."""
     run('python setup.py test')
 
 
 @task
-def test_tox():
+def test_tox(ctx):
     """Run tests with tox."""
     run('tox')
 
 
 @task
-def test_sdist():
+def test_sdist(ctx):
     """Test sdist build and install."""
-    clean()
+    clean(ctx)
     run('python setup.py sdist')
     run('pip install --force-reinstall --upgrade dist/*.gz')
 
 
 @task
-def test_bdist_wheel():
+def test_bdist_wheel(ctx):
     """Test building bdist wheel and install."""
-    clean()
+    clean(ctx)
     run('python setup.py bdist_wheel')
     run('pip install --force-reinstall --upgrade dist/*.whl')
 
 
 @task
-def test_dist():
+def test_dist(ctx):
     """Test both sdist and bdist wheel and install."""
-    test_sdist()
-    test_bdist_wheel()
+    test_sdist(ctx)
+    test_bdist_wheel(ctx)
 
 
 @task
-def test_all():
+def test_all(ctx):
     """Run all tests; unit, tox, dist."""
-    test()
-    test_tox()
-    test_dist()
+    test(ctx)
+    test_tox(ctx)
+    test_dist(ctx)


### PR DESCRIPTION
invoke 0.13.0 had an incompatible change (the context gets passed into each task), we ran into this during our last release and we pinned invoke (08af61e9ad3ca3d5e7345226c481b5c6ed0eba87). This upgrades invoke and makes the corresponding changes to our tasks file.