### PR TITLE
Strongarm is now DNSWatch.

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -3,11 +3,12 @@
 release history
 ---------------
 
-next
-++++
+0.2 (2018-06-29)
+++++++++++++++++
 
 * Fixed an exception when invalid JSON is returned from the Strongarm API. See
   #32. Thanks to @kovacsbalu for reporting and fixing the issue.
+* Update the default API host to point to DNSWatch.
 
 0.1.5 (2016-6-22)
 +++++++++++++++++

--- a/strongarm/__init__.py
+++ b/strongarm/__init__.py
@@ -9,7 +9,7 @@ __version__ = '0.1.5'
 __license__ = 'Apache 2.0'
 
 
-host = 'https://app.strongarm.io'
+host = 'https://dnswatch.watchguard.com'
 api_key = None
 api_version = '0.1.0'  # Developers generally should not change this.
 

--- a/strongarm/common.py
+++ b/strongarm/common.py
@@ -56,6 +56,10 @@ def request(method, endpoint, **kwargs):
     kwargs['headers']['Accept'] = ('application/json; version=%s' %
                                    strongarm.api_version)
 
+    # Don't allow requests to follow redirects, it is generally bad practice to
+    # allow an API library to follow any redirects.
+    kwargs['allow_redirects'] = False
+
     # This should only be used for development, never in a production
     # environment.
     if strongarm._ignore_certificates is True:


### PR DESCRIPTION
`app.strongarm.io` is now a redirect to `dnswatch.watchguard.com`.

This also disables following redirects, which was showing a weird error message since (I think) some of the headers were being dropped while following the redirect.

Without this change stronglib cannot currently connect to DNSWatch.