### PR TITLE
Bump requirements and supported Python versions

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -31,8 +31,8 @@ tests_require = [
 
 
 install_requires = [
-    'requests==2.7.0',
-    'six==1.9.0',
+    'requests==2.19.1',
+    'six==1.11.0',
 ]
 
 

--- a/tox.ini
+++ b/tox.ini
@@ -4,7 +4,7 @@
 # and then run "tox" from this directory.
 
 [tox]
-envlist = py27, py33, py34, py35
+envlist = py27, py34, py35, py36, py37
 skip_missing_interpreters = True
 
 [testenv]


### PR DESCRIPTION
This drops support for Python 3.3 (which is end-of-life), adds support for Python 3.6 and 3.7.

It also bumps the install requirements of `requests` and `six` to the latest version. The package should work with older versions, but is unsupported in that configuration.