### PR TITLE
Simplify test setup

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,7 +10,7 @@ matrix:
     - python: 3.7
       dist: xenial
       sudo: true
-script: inv test
+script: py.test
 after_success: coveralls
 notifications:
   email: false

--- a/README.rst
+++ b/README.rst
@@ -56,6 +56,21 @@ usage
     # delete a blackholed domain
     domain.delete()
 
+development
+-----------
+
+In order to develop stronglib you must install the requirements files.
+
+.. code-block:: bash
+
+    pip install -r requirements.txt
+
+Use pytest to run the test suite:
+
+.. code-block:: bash
+
+    py.test
+
 contribute
 ----------
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,8 +2,12 @@
 # for installing the package and running unit tests are defined in setup.py.
 -e .
 
-# Include tox here instead of in setup.py because it is not _required_ for
-# running unit tests but helps standardizing testing during development.
+# Running tests.
+pytest
+pytest-cov
+responses
+
+# Running tests in multiple environments.
 tox==3.2.0
 
 # Include invoke in dev.

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,2 +1,7 @@
 [wheel]
 universal = 1
+
+
+[tool:pytest]
+addopts = --cov strongarm
+testpaths = tests

--- a/setup.py
+++ b/setup.py
@@ -3,31 +3,6 @@ import sys
 import codecs
 
 from setuptools import setup, find_packages
-from setuptools.command.test import test as TestCommand
-
-
-class PyTest(TestCommand):
-    # `$ python setup.py test' simply installs minimal requirements
-    # and runs the tests with no fancy stuff like parallel execution.
-    def finalize_options(self):
-        TestCommand.finalize_options(self)
-        self.test_args = [
-            '--cov', './strongarm',
-            '--doctest-modules', '--verbose',
-            './tests'
-        ]
-        self.test_suite = True
-
-    def run_tests(self):
-        import pytest
-        sys.exit(pytest.main(self.test_args))
-
-
-tests_require = [
-    'pytest',
-    'pytest-cov',
-    'responses',
-]
 
 
 install_requires = [
@@ -52,24 +27,23 @@ setup(
     version=version(),
     description='A Python library for strongarm.io API',
     long_description=long_description(),
-    url='http://strongarm.io/',
+    url='https://dnswatch.watchguard.com',
     download_url='https://github.com/percipient/stronglib',
     author='Percipient Networks, LLC',
     author_email='support@strongarm.io',
     license='Apache 2.0',
     packages=find_packages(),
     install_requires=install_requires,
-    tests_require=tests_require,
-    cmdclass={'test': PyTest},
     classifiers=[
         'Development Status :: 4 - Beta',
         'Programming Language :: Python',
         'Programming Language :: Python :: 2',
         'Programming Language :: Python :: 2.7',
         'Programming Language :: Python :: 3',
-        'Programming Language :: Python :: 3.3',
         'Programming Language :: Python :: 3.4',
         'Programming Language :: Python :: 3.5',
+        'Programming Language :: Python :: 3.6',
+        'Programming Language :: Python :: 3.7',
         'Intended Audience :: Developers',
         'License :: OSI Approved :: Apache Software License',
         'Topic :: Internet :: WWW/HTTP',

--- a/tasks/__init__.py
+++ b/tasks/__init__.py
@@ -38,7 +38,7 @@ def uninstall_all(ctx):
 @task
 def test(ctx):
     """Run stronglib unittests."""
-    run('python setup.py test')
+    run('py.test')
 
 
 @task

--- a/tox.ini
+++ b/tox.ini
@@ -8,5 +8,5 @@ envlist = py27, py34, py35, py36, py37
 skip_missing_interpreters = True
 
 [testenv]
-commands = {envpython} setup.py test
+commands = py.test
 deps =


### PR DESCRIPTION
This simplifies our test setup by removing the `python setup.py test` and replacing it with just using `py.test` directly.

Hopefully this will avoid some of the intermittent failures I've seen in pull requests.