### PR TITLE
Update requests to the latest version

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -6,7 +6,7 @@ from setuptools import setup, find_packages
 
 
 install_requires = [
-    'requests==2.19.1',
+    'requests==2.21.0',
     'six==1.11.0',
 ]
 


### PR DESCRIPTION
This updates requests to a newer release, we should likely re-evaluate why this is pinned to a specific version, I do not believe this is necessary.